### PR TITLE
Scripts: remove pymongo's "timeout" parameter

### DIFF
--- a/scripts/generate_thumbs.py
+++ b/scripts/generate_thumbs.py
@@ -81,7 +81,7 @@ def generate_thumbs(db, config, body_id):
     'depublication': {'$exists': False},
     'body': DBRef('body', ObjectId(body_id))
   }
-  for single_file in db.file.find(query, timeout=False):
+  for single_file in db.file.find(query):
     # Dateiinfo abholen
     if single_file['modified'] > single_file['thumbnailsGenerated']:
       # Thumbnails müssen erneuert werden
@@ -93,7 +93,7 @@ def generate_thumbs(db, config, body_id):
     'depublication': {'$exists': False},
     'body': DBRef('body', ObjectId(body_id))
   }
-  for single_file in db.file.find(query, timeout=False):
+  for single_file in db.file.find(query):
     if 'file' not in single_file:
       print "FATAL! missing file"
     else:


### PR DESCRIPTION
The parameter used before ("timeout") was replaced with
"no_cursor_timeout" in pymongo v3.0:
  http://api.mongodb.com/python/current/changelog.html#changes-to-find-and-find-one

The other occourences of "find" within in this module do not provide a timeout parameter, thus
it can probably be removed safely.
